### PR TITLE
feat: audio gain, conversation window, and health probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- **Audio gain.** `audio.ApplyGain` scales 16-bit PCM and clips, and
+  `processor.NewAudioGain` applies that to every audio frame that passes
+  through, so a session can raise or lower the microphone or the spoken output
+  without changing the transport.
+
+- **A conversation window.** `frames.LLMContext.KeepLastMessages` keeps only the
+  last n messages, leaving the system prompt, tools and recall alone. Long
+  sessions can bound what the model is shown without rewriting the rest of the
+  context.
+
+- **A readiness endpoint and a version command.** `health.Handler` serves a
+  small JSON `{"status":"ok"}` probe. The echo example mounts it at `/healthz`.
+  `voxigo version` prints the module version from build info.
+
 - **A user turn processor.** `turns.NewUserTurnProcessor` decides the user's
   turn in a processor of its own, so the decision can be made once and shared
   by several aggregators, or placed at a particular point in the pipeline. The

--- a/audio/utils.go
+++ b/audio/utils.go
@@ -35,6 +35,32 @@ func IsSilence(pcm []byte) bool {
 	return true
 }
 
+// ApplyGain scales 16-bit signed PCM by gain and clips each sample to the
+// 16-bit range. A gain of 1 leaves the buffer unchanged (the same slice is
+// returned). A gain of 0 is silence. Negative gain inverts the phase. A trailing
+// odd byte is left as it was, matching IsSilence and MixAudio.
+func ApplyGain(pcm []byte, gain float64) []byte {
+	if len(pcm) < 2 || gain == 1 {
+		return pcm
+	}
+	out := make([]byte, len(pcm))
+	copy(out, pcm)
+	for i := 0; i+1 < len(out); i += 2 {
+		s := float64(int16(binary.LittleEndian.Uint16(out[i:]))) * gain
+		var clipped int32
+		switch {
+		case s > 32767:
+			clipped = 32767
+		case s < -32768:
+			clipped = -32768
+		default:
+			clipped = int32(s)
+		}
+		binary.LittleEndian.PutUint16(out[i:], uint16(clampInt16(clipped)))
+	}
+	return out
+}
+
 // MixAudio sums two streams of 16-bit signed PCM sample by sample, clipping the
 // result to the 16-bit range. The streams need not be the same length: the
 // shorter one is treated as though it were padded with silence, so the result is

--- a/audio/utils_test.go
+++ b/audio/utils_test.go
@@ -64,6 +64,35 @@ func equal(got []int16, want ...int16) bool {
 	return true
 }
 
+func TestApplyGain(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		gain float64
+		want []int16
+	}{
+		{"unity returns the same samples", pcm(100, -200), 1, []int16{100, -200}},
+		{"double", pcm(100, -200), 2, []int16{200, -400}},
+		{"half", pcm(100, -200), 0.5, []int16{50, -100}},
+		{"silence", pcm(100, -200), 0, []int16{0, 0}},
+		{"phase invert", pcm(100, -200), -1, []int16{-100, 200}},
+		{"positive clip", pcm(20000), 2, []int16{32767}},
+		{"negative clip", pcm(-20000), 2, []int16{-32768}},
+		{"empty", nil, 2, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := audio.ApplyGain(tt.in, tt.gain)
+			if tt.gain == 1 && len(tt.in) >= 2 && &got[0] != &tt.in[0] {
+				t.Error("gain of 1 should return the same slice")
+			}
+			if !equal(samples(got), tt.want...) {
+				t.Errorf("ApplyGain() = %v, want %v", samples(got), tt.want)
+			}
+		})
+	}
+}
+
 func TestMixAudio(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cmd/voxigo/main.go
+++ b/cmd/voxigo/main.go
@@ -36,6 +36,6 @@ func rootCmd() *cobra.Command {
 		Short:        "Tooling for building and testing voxigo voice agents",
 		SilenceUsage: true,
 	}
-	root.AddCommand(evalCmd())
+	root.AddCommand(evalCmd(), versionCmd())
 	return root
 }

--- a/cmd/voxigo/version.go
+++ b/cmd/voxigo/version.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"runtime/debug"
+
+	"github.com/spf13/cobra"
+)
+
+// versionCmd is `voxigo version`.
+func versionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the voxigo module version",
+		Run: func(cmd *cobra.Command, _ []string) {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), moduleVersion())
+		},
+	}
+}
+
+// moduleVersion reports the module version from build info, or "devel" when
+// the binary was built from a working tree that is not a published module.
+func moduleVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok || info == nil {
+		return "devel"
+	}
+	if v := info.Main.Version; v != "" && v != "(devel)" {
+		return v
+	}
+	return "devel"
+}

--- a/cmd/voxigo/version_test.go
+++ b/cmd/voxigo/version_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestVersionCmdPrintsAVersion(t *testing.T) {
+	cmd := versionCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	got := strings.TrimSpace(buf.String())
+	if got == "" {
+		t.Fatal("version printed nothing")
+	}
+}
+
+func TestModuleVersionNeverEmpty(t *testing.T) {
+	if got := moduleVersion(); got == "" {
+		t.Fatal("moduleVersion() is empty")
+	}
+}

--- a/docs/concepts/llm-context.md
+++ b/docs/concepts/llm-context.md
@@ -29,6 +29,7 @@ n := convo.EstimatedTokens()
 convo.SetSystem("You are terse.") // swap the prompt mid-conversation
 convo.SetTools(tools)             // change advertised tools
 convo.SetToolChoice(frames.ToolChoiceAuto)
+convo.KeepLastMessages(20)        // bound what the model is shown
 ```
 
 A `Message` is a role plus text, and optionally tool calls or tool results:

--- a/docs/guides/audio.md
+++ b/docs/guides/audio.md
@@ -89,6 +89,10 @@ Treat the error as "run without it" rather than fatal, so the bot works on
 machines that do not have the library. `AudioInFilter` takes any `audio.Filter`,
 so a custom one (gain, a high-pass, your own model) drops in the same way.
 
+To raise or lower PCM without a filter, `audio.ApplyGain` scales 16-bit samples
+and clips. `processor.NewAudioGain` does that to every audio frame in the
+pipeline.
+
 Denoising helps in genuinely noisy rooms and can hurt otherwise: it removes
 information the VAD uses. Measure before shipping it.
 

--- a/examples/echo/main.go
+++ b/examples/echo/main.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/nuxflix/voxigo/audio/opus"
 	"github.com/nuxflix/voxigo/frames"
+	"github.com/nuxflix/voxigo/health"
 	"github.com/nuxflix/voxigo/pipeline"
 	"github.com/nuxflix/voxigo/processor"
 	"github.com/nuxflix/voxigo/transport"
@@ -35,6 +36,7 @@ func main() {
 		log.Fatal(err)
 	}
 	http.Handle("/", http.FileServer(http.FS(static)))
+	http.Handle("/healthz", health.Handler("echo", ""))
 	http.HandleFunc("/offer", handleOffer)
 
 	slog.Info("voxigo echo bot listening", "url", "http://localhost"+addr)

--- a/frames/llm_context.go
+++ b/frames/llm_context.go
@@ -375,6 +375,22 @@ func (c *LLMContext) TransformMessages(transform func([]Message) []Message) {
 	c.SetMessages(transform(c.Messages()))
 }
 
+// KeepLastMessages drops every conversation message except the last n. The
+// system prompt, tools and recall stay. n <= 0 clears the messages. A window
+// that would cut through a tool call and its result is the caller's to avoid;
+// the method does not regroup turns.
+func (c *LLMContext) KeepLastMessages(n int) {
+	c.TransformMessages(func(msgs []Message) []Message {
+		if n <= 0 {
+			return nil
+		}
+		if len(msgs) <= n {
+			return msgs
+		}
+		return msgs[len(msgs)-n:]
+	})
+}
+
 // AddUserMessage appends a user message.
 func (c *LLMContext) AddUserMessage(text string) {
 	c.mu.Lock()

--- a/frames/llm_context_test.go
+++ b/frames/llm_context_test.go
@@ -244,3 +244,30 @@ func TestSetMessagesDoesNotAliasTheCaller(t *testing.T) {
 		t.Errorf("context result = %q, want it untouched by the caller's slice", got)
 	}
 }
+
+func TestKeepLastMessages(t *testing.T) {
+	c := frames.NewLLMContext("be brief")
+	c.AddUserMessage("one")
+	c.AddAssistantMessage("two")
+	c.AddUserMessage("three")
+	c.AddAssistantMessage("four")
+
+	c.KeepLastMessages(2)
+	got := c.Messages()
+	if len(got) != 2 || got[0].Text != "three" || got[1].Text != "four" {
+		t.Fatalf("KeepLastMessages(2) = %+v, want the last two turns", got)
+	}
+	if !strings.Contains(c.System(), "be brief") {
+		t.Error("KeepLastMessages dropped the system prompt")
+	}
+
+	c.KeepLastMessages(10)
+	if len(c.Messages()) != 2 {
+		t.Fatalf("KeepLastMessages(10) changed a shorter conversation: %d", len(c.Messages()))
+	}
+
+	c.KeepLastMessages(0)
+	if len(c.Messages()) != 0 {
+		t.Fatalf("KeepLastMessages(0) = %d messages, want none", len(c.Messages()))
+	}
+}

--- a/health/health.go
+++ b/health/health.go
@@ -1,0 +1,30 @@
+// Package health serves a small JSON readiness response for a voxigo bot.
+package health
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Response is what Handler writes on success.
+type Response struct {
+	Status  string `json:"status"`
+	Service string `json:"service,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+
+// Handler returns an endpoint that answers 200 with {"status":"ok"} plus the
+// optional service name and version. It is for a process probe, not a check of
+// every downstream API key.
+func Handler(service, version string) http.Handler {
+	body, err := json.Marshal(Response{Status: "ok", Service: service, Version: version})
+	if err != nil {
+		// A struct of strings cannot fail to marshal; keep the handler honest.
+		body = []byte(`{"status":"ok"}`)
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	})
+}

--- a/health/health_test.go
+++ b/health/health_test.go
@@ -1,0 +1,30 @@
+package health_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nuxflix/voxigo/health"
+)
+
+func TestHandler(t *testing.T) {
+	h := health.Handler("echo", "0.0.5")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", http.NoBody))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("Content-Type = %q", ct)
+	}
+	var got health.Response
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != "ok" || got.Service != "echo" || got.Version != "0.0.5" {
+		t.Fatalf("response = %+v", got)
+	}
+}

--- a/processor/gain.go
+++ b/processor/gain.go
@@ -1,0 +1,35 @@
+package processor
+
+import (
+	"context"
+
+	"github.com/nuxflix/voxigo/audio"
+	"github.com/nuxflix/voxigo/frames"
+)
+
+// AudioGain scales the PCM on every audio frame that passes through it. A gain
+// of 1 is a no-op. It is for a session that needs the incoming microphone or
+// the outgoing speech a little louder or quieter without changing the transport.
+type AudioGain struct {
+	*Base
+	gain float64
+}
+
+// NewAudioGain builds a processor that multiplies every audio frame by gain.
+func NewAudioGain(gain float64) *AudioGain {
+	g := &AudioGain{gain: gain}
+	g.Base = New("AudioGain", g)
+	return g
+}
+
+// ProcessFrame applies the gain to audio frames and forwards everything else.
+func (g *AudioGain) ProcessFrame(ctx context.Context, f frames.Frame, dir Direction) error {
+	if err := g.Base.ProcessFrame(ctx, f, dir); err != nil {
+		return err
+	}
+	if af, ok := f.(frames.AudioFrame); ok {
+		data := af.AudioData()
+		data.Audio = audio.ApplyGain(data.Audio, g.gain)
+	}
+	return g.PushFrame(ctx, f, dir)
+}

--- a/processor/gain_test.go
+++ b/processor/gain_test.go
@@ -1,0 +1,57 @@
+package processor_test
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/nuxflix/voxigo/clock"
+	"github.com/nuxflix/voxigo/frames"
+	"github.com/nuxflix/voxigo/processor"
+)
+
+func pcm16(samples ...int16) []byte {
+	b := make([]byte, len(samples)*2)
+	for i, s := range samples {
+		binary.LittleEndian.PutUint16(b[i*2:], uint16(s))
+	}
+	return b
+}
+
+func TestAudioGainScalesInputAndPassesOtherFrames(t *testing.T) {
+	g := processor.NewAudioGain(2)
+	c := newCapture()
+	g.Link(c)
+
+	ctx := context.Background()
+	setup := processor.Setup{Clock: clock.NewSystem()}
+	if err := g.Setup(ctx, setup); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Setup(ctx, setup); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = g.Cleanup(ctx)
+		_ = c.Cleanup(ctx)
+	})
+
+	_ = g.QueueFrame(ctx, frames.NewStartFrame(), processor.Downstream)
+	mustReceive[*frames.StartFrame](t, c.got, "StartFrame")
+
+	in := frames.NewInputAudioRawFrame(pcm16(100, -50), 16000, 1)
+	_ = g.QueueFrame(ctx, in, processor.Downstream)
+	got := mustReceive[*frames.InputAudioRawFrame](t, c.got, "InputAudioRawFrame")
+	s0 := int16(binary.LittleEndian.Uint16(got.Audio[0:]))
+	s1 := int16(binary.LittleEndian.Uint16(got.Audio[2:]))
+	if s0 != 200 || s1 != -100 {
+		t.Fatalf("gained samples = %d, %d, want 200, -100", s0, s1)
+	}
+
+	text := frames.NewTextFrame("leave me")
+	_ = g.QueueFrame(ctx, text, processor.Downstream)
+	out := mustReceive[*frames.TextFrame](t, c.got, "TextFrame")
+	if out.Text != "leave me" {
+		t.Fatalf("Text = %q", out.Text)
+	}
+}


### PR DESCRIPTION
## Summary
- `audio.ApplyGain` and `processor.NewAudioGain` scale 16-bit PCM on the pipeline.
- `frames.LLMContext.KeepLastMessages` keeps only the last n conversation messages.
- `health.Handler` serves a JSON readiness probe; the echo bot mounts it at `/healthz`. `voxigo version` prints the module version.

## Test plan
- [ ] `go test ./audio ./frames ./health ./processor ./cmd/voxigo`
- [ ] Run the echo example and `GET /healthz`
- [ ] `go run ./cmd/voxigo version`
