### PR TITLE
feat: peak normalize, mute, and conversation transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- **Peak normalization.** `audio.Peak` and `audio.PeakNormalize` measure and
+  raise a PCM buffer to a target peak. `processor.NewAudioNormalize` does that
+  to every audio frame, so a quiet microphone can sit at a consistent level.
+
+- **A mute processor.** `processor.NewAudioMute` replaces audio with silence
+  while armed, without changing frame length, and can be flipped from another
+  goroutine.
+
+- **A readable transcript.** `frames.LLMContext.Transcript` joins conversation
+  turns as `role: text` lines. `ClearMessages` drops the turns and leaves the
+  system prompt, tools and recall.
+
 - **A user turn processor.** `turns.NewUserTurnProcessor` decides the user's
   turn in a processor of its own, so the decision can be made once and shared
   by several aggregators, or placed at a particular point in the pipeline. The

--- a/audio/utils.go
+++ b/audio/utils.go
@@ -35,6 +35,52 @@ func IsSilence(pcm []byte) bool {
 	return true
 }
 
+// Peak is the largest absolute 16-bit sample in pcm. Silence and an empty
+// buffer report 0. A trailing odd byte is ignored.
+func Peak(pcm []byte) int {
+	peak := 0
+	for i := 0; i+1 < len(pcm); i += 2 {
+		sample := int(int16(binary.LittleEndian.Uint16(pcm[i:])))
+		if sample < 0 {
+			sample = -sample
+		}
+		if sample > peak {
+			peak = sample
+		}
+	}
+	return peak
+}
+
+// PeakNormalize scales pcm so its peak matches target, clipping if the scale
+// overflows. target <= 0 or a silent buffer leaves the samples unchanged. A
+// target above 32767 is treated as full scale.
+func PeakNormalize(pcm []byte, target int) []byte {
+	if target > 32767 {
+		target = 32767
+	}
+	peak := Peak(pcm)
+	if len(pcm) < 2 || target <= 0 || peak == 0 || peak == target {
+		return pcm
+	}
+	gain := float64(target) / float64(peak)
+	out := make([]byte, len(pcm))
+	copy(out, pcm)
+	for i := 0; i+1 < len(out); i += 2 {
+		s := float64(int16(binary.LittleEndian.Uint16(out[i:]))) * gain
+		var clipped int32
+		switch {
+		case s > 32767:
+			clipped = 32767
+		case s < -32768:
+			clipped = -32768
+		default:
+			clipped = int32(s)
+		}
+		binary.LittleEndian.PutUint16(out[i:], uint16(clampInt16(clipped)))
+	}
+	return out
+}
+
 // MixAudio sums two streams of 16-bit signed PCM sample by sample, clipping the
 // result to the 16-bit range. The streams need not be the same length: the
 // shorter one is treated as though it were padded with silence, so the result is

--- a/audio/utils_test.go
+++ b/audio/utils_test.go
@@ -64,6 +64,29 @@ func equal(got []int16, want ...int16) bool {
 	return true
 }
 
+func TestPeak(t *testing.T) {
+	if got := audio.Peak(nil); got != 0 {
+		t.Fatalf("Peak(nil) = %d, want 0", got)
+	}
+	if got := audio.Peak(pcm(10, -40, 25)); got != 40 {
+		t.Fatalf("Peak() = %d, want 40", got)
+	}
+}
+
+func TestPeakNormalize(t *testing.T) {
+	got := audio.PeakNormalize(pcm(1000, -2000), 4000)
+	if !equal(samples(got), 2000, -4000) {
+		t.Fatalf("PeakNormalize() = %v, want 2000, -4000", samples(got))
+	}
+	if !equal(samples(audio.PeakNormalize(pcm(0, 0), 4000)), 0, 0) {
+		t.Fatal("silent buffer should stay silent")
+	}
+	same := pcm(4000)
+	if got := audio.PeakNormalize(same, 4000); !equal(samples(got), 4000) {
+		t.Fatalf("already at target = %v", samples(got))
+	}
+}
+
 func TestMixAudio(t *testing.T) {
 	tests := []struct {
 		name string

--- a/docs/concepts/llm-context.md
+++ b/docs/concepts/llm-context.md
@@ -29,6 +29,8 @@ n := convo.EstimatedTokens()
 convo.SetSystem("You are terse.") // swap the prompt mid-conversation
 convo.SetTools(tools)             // change advertised tools
 convo.SetToolChoice(frames.ToolChoiceAuto)
+text := convo.Transcript()        // "user: …\nassistant: …"
+convo.ClearMessages()             // drop turns, keep the prompt
 ```
 
 A `Message` is a role plus text, and optionally tool calls or tool results:

--- a/docs/guides/audio.md
+++ b/docs/guides/audio.md
@@ -89,6 +89,10 @@ Treat the error as "run without it" rather than fatal, so the bot works on
 machines that do not have the library. `AudioInFilter` takes any `audio.Filter`,
 so a custom one (gain, a high-pass, your own model) drops in the same way.
 
+`audio.PeakNormalize` raises a buffer to a target peak. `processor.NewAudioNormalize`
+does that in the pipeline. `processor.NewAudioMute` replaces audio with silence
+while armed, keeping the frame length so the rest of the pipeline still ticks.
+
 Denoising helps in genuinely noisy rooms and can hurt otherwise: it removes
 information the VAD uses. Measure before shipping it.
 

--- a/frames/llm_context.go
+++ b/frames/llm_context.go
@@ -375,6 +375,32 @@ func (c *LLMContext) TransformMessages(transform func([]Message) []Message) {
 	c.SetMessages(transform(c.Messages()))
 }
 
+// ClearMessages drops every conversation message. The system prompt, tools and
+// recall stay.
+func (c *LLMContext) ClearMessages() {
+	c.SetMessages(nil)
+}
+
+// Transcript renders the conversation as "role: text" lines, one per message
+// that has text. Tool-only messages are omitted. The system prompt is not
+// included; it is not a conversation turn.
+func (c *LLMContext) Transcript() string {
+	msgs := c.Messages()
+	var b strings.Builder
+	for _, m := range msgs {
+		if m.Text == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(string(m.Role))
+		b.WriteString(": ")
+		b.WriteString(m.Text)
+	}
+	return b.String()
+}
+
 // AddUserMessage appends a user message.
 func (c *LLMContext) AddUserMessage(text string) {
 	c.mu.Lock()

--- a/frames/llm_context_test.go
+++ b/frames/llm_context_test.go
@@ -244,3 +244,27 @@ func TestSetMessagesDoesNotAliasTheCaller(t *testing.T) {
 		t.Errorf("context result = %q, want it untouched by the caller's slice", got)
 	}
 }
+
+func TestTranscriptAndClearMessages(t *testing.T) {
+	c := frames.NewLLMContext("be brief")
+	c.AddUserMessage("hello")
+	c.AddAssistantMessage("hi there")
+	c.AddMessage(frames.Message{Role: frames.RoleAssistant, ToolCalls: []frames.ToolCall{{ID: "1", Name: "lookup"}}})
+
+	got := c.Transcript()
+	want := "user: hello\nassistant: hi there"
+	if got != want {
+		t.Fatalf("Transcript() = %q, want %q", got, want)
+	}
+
+	c.ClearMessages()
+	if len(c.Messages()) != 0 {
+		t.Fatalf("ClearMessages left %d messages", len(c.Messages()))
+	}
+	if !strings.Contains(c.System(), "be brief") {
+		t.Error("ClearMessages dropped the system prompt")
+	}
+	if c.Transcript() != "" {
+		t.Fatalf("Transcript() after clear = %q", c.Transcript())
+	}
+}

--- a/processor/mute.go
+++ b/processor/mute.go
@@ -1,0 +1,49 @@
+package processor
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/nuxflix/voxigo/frames"
+)
+
+// AudioMute replaces audio with silence while it is muted, keeping the frame
+// length so the rest of the pipeline still sees a regular stream. Other frames
+// pass through. Mute can be flipped from another goroutine.
+type AudioMute struct {
+	*Base
+	muted atomic.Bool
+}
+
+// NewAudioMute builds a mute processor. It starts unmuted.
+func NewAudioMute() *AudioMute {
+	m := &AudioMute{}
+	m.Base = New("AudioMute", m)
+	return m
+}
+
+// SetMuted turns silence on or off for later audio frames.
+func (m *AudioMute) SetMuted(muted bool) {
+	m.muted.Store(muted)
+}
+
+// Muted reports whether later audio frames are silenced.
+func (m *AudioMute) Muted() bool {
+	return m.muted.Load()
+}
+
+// ProcessFrame zeros audio while muted and forwards everything else.
+func (m *AudioMute) ProcessFrame(ctx context.Context, f frames.Frame, dir Direction) error {
+	if err := m.Base.ProcessFrame(ctx, f, dir); err != nil {
+		return err
+	}
+	if m.muted.Load() {
+		if af, ok := f.(frames.AudioFrame); ok {
+			data := af.AudioData()
+			if len(data.Audio) > 0 {
+				data.Audio = make([]byte, len(data.Audio))
+			}
+		}
+	}
+	return m.PushFrame(ctx, f, dir)
+}

--- a/processor/mute_test.go
+++ b/processor/mute_test.go
@@ -1,0 +1,57 @@
+package processor_test
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/nuxflix/voxigo/clock"
+	"github.com/nuxflix/voxigo/frames"
+	"github.com/nuxflix/voxigo/processor"
+)
+
+func TestAudioMuteSilencesWhenArmed(t *testing.T) {
+	m := processor.NewAudioMute()
+	if m.Muted() {
+		t.Fatal("starts muted")
+	}
+	c := newCapture()
+	m.Link(c)
+
+	ctx := context.Background()
+	setup := processor.Setup{Clock: clock.NewSystem()}
+	if err := m.Setup(ctx, setup); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Setup(ctx, setup); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = m.Cleanup(ctx)
+		_ = c.Cleanup(ctx)
+	})
+
+	_ = m.QueueFrame(ctx, frames.NewStartFrame(), processor.Downstream)
+	mustReceive[*frames.StartFrame](t, c.got, "StartFrame")
+
+	open := frames.NewInputAudioRawFrame(pcm16le(100, -50), 16000, 1)
+	_ = m.QueueFrame(ctx, open, processor.Downstream)
+	live := mustReceive[*frames.InputAudioRawFrame](t, c.got, "open audio")
+	if int16(binary.LittleEndian.Uint16(live.Audio)) != 100 {
+		t.Fatal("unmuted audio was changed")
+	}
+
+	m.SetMuted(true)
+	if !m.Muted() {
+		t.Fatal("SetMuted(true) did not stick")
+	}
+	held := frames.NewInputAudioRawFrame(pcm16le(100, -50), 16000, 1)
+	_ = m.QueueFrame(ctx, held, processor.Downstream)
+	quiet := mustReceive[*frames.InputAudioRawFrame](t, c.got, "muted audio")
+	if int16(binary.LittleEndian.Uint16(quiet.Audio)) != 0 || int16(binary.LittleEndian.Uint16(quiet.Audio[2:])) != 0 {
+		t.Fatal("muted audio was not silence")
+	}
+	if len(quiet.Audio) != len(held.Audio) {
+		t.Fatal("mute changed the frame length")
+	}
+}

--- a/processor/normalize.go
+++ b/processor/normalize.go
@@ -1,0 +1,34 @@
+package processor
+
+import (
+	"context"
+
+	"github.com/nuxflix/voxigo/audio"
+	"github.com/nuxflix/voxigo/frames"
+)
+
+// AudioNormalize raises or lowers each audio frame so its peak matches Target.
+// A target of 0 uses full scale (32767). Silent frames are left alone.
+type AudioNormalize struct {
+	*Base
+	target int
+}
+
+// NewAudioNormalize builds a processor that peak-normalizes every audio frame.
+func NewAudioNormalize(target int) *AudioNormalize {
+	n := &AudioNormalize{target: target}
+	n.Base = New("AudioNormalize", n)
+	return n
+}
+
+// ProcessFrame normalizes audio frames and forwards everything else.
+func (n *AudioNormalize) ProcessFrame(ctx context.Context, f frames.Frame, dir Direction) error {
+	if err := n.Base.ProcessFrame(ctx, f, dir); err != nil {
+		return err
+	}
+	if af, ok := f.(frames.AudioFrame); ok {
+		data := af.AudioData()
+		data.Audio = audio.PeakNormalize(data.Audio, n.target)
+	}
+	return n.PushFrame(ctx, f, dir)
+}

--- a/processor/normalize_test.go
+++ b/processor/normalize_test.go
@@ -1,0 +1,50 @@
+package processor_test
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/nuxflix/voxigo/clock"
+	"github.com/nuxflix/voxigo/frames"
+	"github.com/nuxflix/voxigo/processor"
+)
+
+func pcm16le(samples ...int16) []byte {
+	b := make([]byte, len(samples)*2)
+	for i, s := range samples {
+		binary.LittleEndian.PutUint16(b[i*2:], uint16(s))
+	}
+	return b
+}
+
+func TestAudioNormalizeRaisesPeak(t *testing.T) {
+	n := processor.NewAudioNormalize(4000)
+	c := newCapture()
+	n.Link(c)
+
+	ctx := context.Background()
+	setup := processor.Setup{Clock: clock.NewSystem()}
+	if err := n.Setup(ctx, setup); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Setup(ctx, setup); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = n.Cleanup(ctx)
+		_ = c.Cleanup(ctx)
+	})
+
+	_ = n.QueueFrame(ctx, frames.NewStartFrame(), processor.Downstream)
+	mustReceive[*frames.StartFrame](t, c.got, "StartFrame")
+
+	in := frames.NewInputAudioRawFrame(pcm16le(1000, -2000), 16000, 1)
+	_ = n.QueueFrame(ctx, in, processor.Downstream)
+	got := mustReceive[*frames.InputAudioRawFrame](t, c.got, "InputAudioRawFrame")
+	s0 := int16(binary.LittleEndian.Uint16(got.Audio[0:]))
+	s1 := int16(binary.LittleEndian.Uint16(got.Audio[2:]))
+	if s0 != 2000 || s1 != -4000 {
+		t.Fatalf("normalized samples = %d, %d, want 2000, -4000", s0, s1)
+	}
+}


### PR DESCRIPTION
## Summary
- `audio.Peak` / `audio.PeakNormalize` and `processor.NewAudioNormalize` raise quiet PCM to a target peak.
- `processor.NewAudioMute` replaces audio with silence while armed, without changing frame length.
- `frames.LLMContext.Transcript` renders turns as `role: text`; `ClearMessages` drops turns and keeps the system prompt.

## Test plan
- [ ] `go test ./audio ./frames ./processor`
- [ ] Mute a live echo session and confirm audio goes silent, then unmute
