### PR TITLE
feat: DC-offset removal and conversation counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- **DC-offset removal.** `audio.RemoveDCOffset` subtracts the mean sample from
+  a 16-bit PCM chunk, and `processor.NewAudioDCBlock` applies that to every
+  audio frame on the pipeline, so a biased microphone does not look like energy.
+
+- **Conversation length and the last spoken assistant turn.**
+  `frames.LLMContext.MessageCount` is the number of messages without copying
+  them. `LastAssistantText` returns the most recent plain assistant reply,
+  skipping tool-call turns.
+
 - **A user turn processor.** `turns.NewUserTurnProcessor` decides the user's
   turn in a processor of its own, so the decision can be made once and shared
   by several aggregators, or placed at a particular point in the pipeline. The

--- a/audio/utils.go
+++ b/audio/utils.go
@@ -35,6 +35,34 @@ func IsSilence(pcm []byte) bool {
 	return true
 }
 
+// RemoveDCOffset subtracts the mean sample value from a chunk of 16-bit signed
+// PCM, so a microphone that sits off zero does not look like constant energy.
+// The result is a copy, clipped to the 16-bit range. An empty buffer, or one
+// that does not complete a sample, is returned unchanged.
+func RemoveDCOffset(pcm []byte) []byte {
+	n := len(pcm) - len(pcm)%2
+	if n == 0 {
+		return pcm
+	}
+	var sum int64
+	count := n / 2
+	for i := 0; i+1 < n; i += 2 {
+		sum += int64(int16(binary.LittleEndian.Uint16(pcm[i:])))
+	}
+	mean := int32(sum / int64(count))
+	if mean == 0 {
+		out := make([]byte, n)
+		copy(out, pcm[:n])
+		return out
+	}
+	out := make([]byte, n)
+	for i := 0; i+1 < n; i += 2 {
+		s := int32(int16(binary.LittleEndian.Uint16(pcm[i:]))) - mean
+		binary.LittleEndian.PutUint16(out[i:], uint16(clampInt16(s)))
+	}
+	return out
+}
+
 // MixAudio sums two streams of 16-bit signed PCM sample by sample, clipping the
 // result to the 16-bit range. The streams need not be the same length: the
 // shorter one is treated as though it were padded with silence, so the result is

--- a/audio/utils_test.go
+++ b/audio/utils_test.go
@@ -64,6 +64,38 @@ func equal(got []int16, want ...int16) bool {
 	return true
 }
 
+func TestRemoveDCOffset(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		want []int16
+	}{
+		{"empty", nil, nil},
+		{"already centered", pcm(10, -10), []int16{10, -10}},
+		{"constant bias becomes silence", pcm(100, 100, 100), []int16{0, 0, 0}},
+		{"mean is subtracted sample by sample", pcm(110, 90), []int16{10, -10}},
+		{"odd trailing byte is ignored", append(pcm(100, 100), 0xFF), []int16{0, 0}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := samples(audio.RemoveDCOffset(tt.in))
+			if !equal(got, tt.want...) {
+				t.Errorf("RemoveDCOffset() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+	t.Run("returns a copy", func(t *testing.T) {
+		in := pcm(100, 100)
+		out := audio.RemoveDCOffset(in)
+		in[0] = 0xFF
+		in[1] = 0x7F
+		if got := samples(out); !equal(got, 0, 0) {
+			t.Errorf("mutating the input reached the result: %v", got)
+		}
+	})
+}
+
 func TestMixAudio(t *testing.T) {
 	tests := []struct {
 		name string

--- a/docs/concepts/llm-context.md
+++ b/docs/concepts/llm-context.md
@@ -24,7 +24,8 @@ long-lived aggregate shared between the aggregators and the LLM service, and it
 convo.AddUserMessage("What's the weather?")
 convo.AddAssistantMessage("Sunny and 22 degrees.")
 msgs := convo.Messages()          // a copy
-n := convo.EstimatedTokens()
+n := convo.MessageCount()
+last := convo.LastAssistantText() // "Sunny and 22 degrees."
 
 convo.SetSystem("You are terse.") // swap the prompt mid-conversation
 convo.SetTools(tools)             // change advertised tools

--- a/docs/guides/audio.md
+++ b/docs/guides/audio.md
@@ -150,6 +150,9 @@ buffer holds audio in memory.
 
 ## Other pieces
 
+- **`audio.RemoveDCOffset`** / **`processor.NewAudioDCBlock`**: subtract the
+  mean sample from a buffer or from every audio frame, so a microphone that sits
+  off zero does not look like constant energy.
 - **`audio/onset`**: finds the first audible sample in a PCM stream, so
   time-to-first-audio metrics measure real speech rather than leading silence.
 - **`audio/chain.go`**: composes several `audio.Filter`s into one.

--- a/frames/llm_context.go
+++ b/frames/llm_context.go
@@ -465,6 +465,29 @@ func (c *LLMContext) Messages() []Message {
 	return cloneMessages(c.messages)
 }
 
+// MessageCount is how many turns are in the conversation, tool-call and
+// tool-result messages included. It does not copy the list.
+func (c *LLMContext) MessageCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.messages)
+}
+
+// LastAssistantText returns the text of the most recent plain assistant turn
+// (one carrying no tool calls or results). An empty string means no spoken
+// assistant turn is in the conversation yet.
+func (c *LLMContext) LastAssistantText() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for i := len(c.messages) - 1; i >= 0; i-- {
+		m := c.messages[i]
+		if m.Role == RoleAssistant && len(m.ToolCalls) == 0 && len(m.ToolResults) == 0 {
+			return m.Text
+		}
+	}
+	return ""
+}
+
 // MessagesFor returns the messages to send to the named provider: every
 // universal one, plus the provider's own, and none written for a different
 // provider. It is what an adapter reads rather than Messages, so a conversation

--- a/frames/llm_context_test.go
+++ b/frames/llm_context_test.go
@@ -244,3 +244,34 @@ func TestSetMessagesDoesNotAliasTheCaller(t *testing.T) {
 		t.Errorf("context result = %q, want it untouched by the caller's slice", got)
 	}
 }
+
+// TestMessageCountAndLastAssistantText cover the two readers that avoid
+// copying the conversation: a length, and the last spoken assistant turn.
+func TestMessageCountAndLastAssistantText(t *testing.T) {
+	c := frames.NewLLMContext("system")
+	if c.MessageCount() != 0 {
+		t.Errorf("MessageCount() = %d, want 0", c.MessageCount())
+	}
+	if got := c.LastAssistantText(); got != "" {
+		t.Errorf("LastAssistantText() = %q, want empty on a new context", got)
+	}
+
+	c.AddUserMessage("hello")
+	c.AddAssistantMessage("first reply")
+	c.AddUserMessage("again")
+	c.AddAssistantMessage("second reply")
+	if c.MessageCount() != 4 {
+		t.Errorf("MessageCount() = %d, want 4", c.MessageCount())
+	}
+	if got := c.LastAssistantText(); got != "second reply" {
+		t.Errorf("LastAssistantText() = %q, want the later assistant turn", got)
+	}
+
+	c.AddAssistantToolCall(frames.ToolCall{ID: "c1", Name: "get_weather"})
+	if c.MessageCount() != 5 {
+		t.Errorf("MessageCount() = %d, want the tool call counted", c.MessageCount())
+	}
+	if got := c.LastAssistantText(); got != "second reply" {
+		t.Errorf("LastAssistantText() = %q, want the spoken turn, not the tool call", got)
+	}
+}

--- a/processor/dcblock.go
+++ b/processor/dcblock.go
@@ -1,0 +1,35 @@
+package processor
+
+import (
+	"context"
+
+	"github.com/nuxflix/voxigo/audio"
+	"github.com/nuxflix/voxigo/frames"
+)
+
+// AudioDCBlock subtracts the mean sample value from every audio frame that
+// passes through it. It is for a microphone that sits off zero, so later energy
+// measures and VAD see the speech rather than a constant bias.
+type AudioDCBlock struct {
+	*Base
+}
+
+// NewAudioDCBlock builds a processor that removes DC offset from each audio
+// frame.
+func NewAudioDCBlock() *AudioDCBlock {
+	p := &AudioDCBlock{}
+	p.Base = New("AudioDCBlock", p)
+	return p
+}
+
+// ProcessFrame recenters audio frames and forwards everything else.
+func (p *AudioDCBlock) ProcessFrame(ctx context.Context, f frames.Frame, dir Direction) error {
+	if err := p.Base.ProcessFrame(ctx, f, dir); err != nil {
+		return err
+	}
+	if af, ok := f.(frames.AudioFrame); ok {
+		data := af.AudioData()
+		data.Audio = audio.RemoveDCOffset(data.Audio)
+	}
+	return p.PushFrame(ctx, f, dir)
+}

--- a/processor/dcblock_test.go
+++ b/processor/dcblock_test.go
@@ -1,0 +1,57 @@
+package processor_test
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/nuxflix/voxigo/clock"
+	"github.com/nuxflix/voxigo/frames"
+	"github.com/nuxflix/voxigo/processor"
+)
+
+func pcm16dc(samples ...int16) []byte {
+	b := make([]byte, len(samples)*2)
+	for i, s := range samples {
+		binary.LittleEndian.PutUint16(b[i*2:], uint16(s))
+	}
+	return b
+}
+
+func TestAudioDCBlockRecentersInputAndPassesOtherFrames(t *testing.T) {
+	p := processor.NewAudioDCBlock()
+	c := newCapture()
+	p.Link(c)
+
+	ctx := context.Background()
+	setup := processor.Setup{Clock: clock.NewSystem()}
+	if err := p.Setup(ctx, setup); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Setup(ctx, setup); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = p.Cleanup(ctx)
+		_ = c.Cleanup(ctx)
+	})
+
+	_ = p.QueueFrame(ctx, frames.NewStartFrame(), processor.Downstream)
+	mustReceive[*frames.StartFrame](t, c.got, "StartFrame")
+
+	in := frames.NewInputAudioRawFrame(pcm16dc(110, 90), 16000, 1)
+	_ = p.QueueFrame(ctx, in, processor.Downstream)
+	got := mustReceive[*frames.InputAudioRawFrame](t, c.got, "InputAudioRawFrame")
+	s0 := int16(binary.LittleEndian.Uint16(got.Audio[0:]))
+	s1 := int16(binary.LittleEndian.Uint16(got.Audio[2:]))
+	if s0 != 10 || s1 != -10 {
+		t.Fatalf("recentered samples = %d, %d, want 10, -10", s0, s1)
+	}
+
+	text := frames.NewTextFrame("leave me")
+	_ = p.QueueFrame(ctx, text, processor.Downstream)
+	out := mustReceive[*frames.TextFrame](t, c.got, "TextFrame")
+	if out.Text != "leave me" {
+		t.Fatalf("Text = %q", out.Text)
+	}
+}


### PR DESCRIPTION
## Summary
- `audio.RemoveDCOffset` and `processor.NewAudioDCBlock` subtract the mean sample so a biased microphone does not look like energy.
- `frames.LLMContext.MessageCount` is the conversation length without copying messages.
- `frames.LLMContext.LastAssistantText` returns the most recent plain assistant reply, skipping tool-call turns.

Independent of the other open session-helper PRs: this branch is from current `main`.

## Test plan
- [ ] `go test ./audio ./frames ./processor`
- [ ] Confirm a constant-bias buffer becomes silence and a centered buffer is unchanged
- [ ] Confirm `LastAssistantText` ignores an assistant tool-call message
