### PR TITLE
feat: stereo deinterleave, invert, and empty check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- **Stereo split and polarity invert.** `audio.DeinterleaveStereo` undoes
+  `InterleaveStereo`. `audio.Invert` and `processor.NewAudioInvert` flip the
+  sign of every sample, clipping the most negative value.
+
+- **An empty-conversation check.** `frames.LLMContext.IsEmpty` reports whether
+  any messages have been written. The system prompt alone does not count.
+
 - **A user turn processor.** `turns.NewUserTurnProcessor` decides the user's
   turn in a processor of its own, so the decision can be made once and shared
   by several aggregators, or placed at a particular point in the pipeline. The

--- a/audio/utils.go
+++ b/audio/utils.go
@@ -71,6 +71,40 @@ func InterleaveStereo(left, right []byte) []byte {
 	return out
 }
 
+// DeinterleaveStereo splits a stereo stream of 16-bit signed PCM (left first:
+// L, R, L, R and so on) back into two mono streams. A trailing half-frame is
+// dropped, because a sample without its pair is not a complete frame. The
+// results are copies, so a later write to the input cannot reach them.
+func DeinterleaveStereo(stereo []byte) (left, right []byte) {
+	n := len(stereo) - len(stereo)%4
+	left = make([]byte, n/2)
+	right = make([]byte, n/2)
+	for i := 0; i+3 < n; i += 4 {
+		copy(left[i/2:], stereo[i:i+2])
+		copy(right[i/2:], stereo[i+2:i+4])
+	}
+	return left, right
+}
+
+// Invert flips the polarity of a chunk of 16-bit signed PCM. The most negative
+// sample has no positive counterpart and is clipped to 32767. The result is a
+// copy. An empty buffer, or one that does not complete a sample, comes back
+// empty.
+func Invert(pcm []byte) []byte {
+	n := len(pcm) - len(pcm)%2
+	out := make([]byte, n)
+	for i := 0; i+1 < n; i += 2 {
+		s := int32(int16(binary.LittleEndian.Uint16(pcm[i:])))
+		if s == -32768 {
+			s = 32767
+		} else {
+			s = -s
+		}
+		binary.LittleEndian.PutUint16(out[i:], uint16(int16(s)))
+	}
+	return out
+}
+
 // clampInt16 saturates a widened sample to the 16-bit range.
 func clampInt16(v int32) int16 {
 	switch {

--- a/audio/utils_test.go
+++ b/audio/utils_test.go
@@ -106,6 +106,48 @@ func TestInterleaveStereo(t *testing.T) {
 	}
 }
 
+func TestDeinterleaveStereo(t *testing.T) {
+	t.Run("undoes InterleaveStereo", func(t *testing.T) {
+		left, right := audio.DeinterleaveStereo(audio.InterleaveStereo(pcm(1, 2), pcm(-1, -2)))
+		if !equal(samples(left), 1, 2) || !equal(samples(right), -1, -2) {
+			t.Errorf("got left %v right %v", samples(left), samples(right))
+		}
+	})
+	t.Run("drops a trailing half-frame", func(t *testing.T) {
+		in := append(pcm(1, -1, 2, -2), 0x03, 0x00)
+		left, right := audio.DeinterleaveStereo(in)
+		if !equal(samples(left), 1, 2) || !equal(samples(right), -1, -2) {
+			t.Errorf("got left %v right %v", samples(left), samples(right))
+		}
+	})
+	t.Run("empty", func(t *testing.T) {
+		left, right := audio.DeinterleaveStereo(nil)
+		if len(left) != 0 || len(right) != 0 {
+			t.Errorf("got left %v right %v", left, right)
+		}
+	})
+}
+
+func TestInvert(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		want []int16
+	}{
+		{"empty", nil, nil},
+		{"flips sign", pcm(100, -50), []int16{-100, 50}},
+		{"the most negative sample clips", pcm(-32768), []int16{32767}},
+		{"odd trailing byte is ignored", append(pcm(10), 0xFF), []int16{-10}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := samples(audio.Invert(tt.in)); !equal(got, tt.want...) {
+				t.Errorf("Invert() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // readWAV pulls the format fields and the data payload back out of a WAV file,
 // so a test can check what a reader would actually see.
 func readWAV(t *testing.T, wav []byte) (numChannels, sampleWidth, sampleRate int, data []byte) {

--- a/docs/concepts/llm-context.md
+++ b/docs/concepts/llm-context.md
@@ -24,7 +24,7 @@ long-lived aggregate shared between the aggregators and the LLM service, and it
 convo.AddUserMessage("What's the weather?")
 convo.AddAssistantMessage("Sunny and 22 degrees.")
 msgs := convo.Messages()          // a copy
-n := convo.EstimatedTokens()
+empty := convo.IsEmpty()          // false once a turn is written
 
 convo.SetSystem("You are terse.") // swap the prompt mid-conversation
 convo.SetTools(tools)             // change advertised tools

--- a/docs/guides/audio.md
+++ b/docs/guides/audio.md
@@ -150,6 +150,10 @@ buffer holds audio in memory.
 
 ## Other pieces
 
+- **`audio.DeinterleaveStereo`**: splits an interleaved stereo buffer back into
+  left and right mono streams.
+- **`audio.Invert`** / **`processor.NewAudioInvert`**: flip polarity on a buffer
+  or on every audio frame, for a session wired out of phase.
 - **`audio/onset`**: finds the first audible sample in a PCM stream, so
   time-to-first-audio metrics measure real speech rather than leading silence.
 - **`audio/chain.go`**: composes several `audio.Filter`s into one.

--- a/frames/llm_context.go
+++ b/frames/llm_context.go
@@ -465,6 +465,15 @@ func (c *LLMContext) Messages() []Message {
 	return cloneMessages(c.messages)
 }
 
+// IsEmpty reports whether the conversation has no messages yet. The system
+// prompt is not a message, so a freshly built context is empty even when it
+// carries a prompt.
+func (c *LLMContext) IsEmpty() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.messages) == 0
+}
+
 // MessagesFor returns the messages to send to the named provider: every
 // universal one, plus the provider's own, and none written for a different
 // provider. It is what an adapter reads rather than Messages, so a conversation

--- a/frames/llm_context_test.go
+++ b/frames/llm_context_test.go
@@ -244,3 +244,20 @@ func TestSetMessagesDoesNotAliasTheCaller(t *testing.T) {
 		t.Errorf("context result = %q, want it untouched by the caller's slice", got)
 	}
 }
+
+// TestIsEmpty treats only the message list as the conversation: a prompt
+// alone is still empty.
+func TestIsEmpty(t *testing.T) {
+	c := frames.NewLLMContext("system")
+	if !c.IsEmpty() {
+		t.Error("a new context should be empty")
+	}
+	c.AddUserMessage("hello")
+	if c.IsEmpty() {
+		t.Error("a context with a user turn should not be empty")
+	}
+	c.SetMessages(nil)
+	if !c.IsEmpty() {
+		t.Error("clearing the messages should make the context empty again")
+	}
+}

--- a/processor/invert.go
+++ b/processor/invert.go
@@ -1,0 +1,35 @@
+package processor
+
+import (
+	"context"
+
+	"github.com/nuxflix/voxigo/audio"
+	"github.com/nuxflix/voxigo/frames"
+)
+
+// AudioInvert flips the polarity of every audio frame that passes through it.
+// It is for a session whose microphone or speaker is wired out of phase with
+// the rest of the mix, so the samples themselves are inverted rather than the
+// hardware.
+type AudioInvert struct {
+	*Base
+}
+
+// NewAudioInvert builds a processor that inverts every audio frame.
+func NewAudioInvert() *AudioInvert {
+	p := &AudioInvert{}
+	p.Base = New("AudioInvert", p)
+	return p
+}
+
+// ProcessFrame inverts audio frames and forwards everything else.
+func (p *AudioInvert) ProcessFrame(ctx context.Context, f frames.Frame, dir Direction) error {
+	if err := p.Base.ProcessFrame(ctx, f, dir); err != nil {
+		return err
+	}
+	if af, ok := f.(frames.AudioFrame); ok {
+		data := af.AudioData()
+		data.Audio = audio.Invert(data.Audio)
+	}
+	return p.PushFrame(ctx, f, dir)
+}

--- a/processor/invert_test.go
+++ b/processor/invert_test.go
@@ -1,0 +1,57 @@
+package processor_test
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/nuxflix/voxigo/clock"
+	"github.com/nuxflix/voxigo/frames"
+	"github.com/nuxflix/voxigo/processor"
+)
+
+func pcm16inv(samples ...int16) []byte {
+	b := make([]byte, len(samples)*2)
+	for i, s := range samples {
+		binary.LittleEndian.PutUint16(b[i*2:], uint16(s))
+	}
+	return b
+}
+
+func TestAudioInvertFlipsInputAndPassesOtherFrames(t *testing.T) {
+	p := processor.NewAudioInvert()
+	c := newCapture()
+	p.Link(c)
+
+	ctx := context.Background()
+	setup := processor.Setup{Clock: clock.NewSystem()}
+	if err := p.Setup(ctx, setup); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Setup(ctx, setup); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = p.Cleanup(ctx)
+		_ = c.Cleanup(ctx)
+	})
+
+	_ = p.QueueFrame(ctx, frames.NewStartFrame(), processor.Downstream)
+	mustReceive[*frames.StartFrame](t, c.got, "StartFrame")
+
+	in := frames.NewInputAudioRawFrame(pcm16inv(100, -50), 16000, 1)
+	_ = p.QueueFrame(ctx, in, processor.Downstream)
+	got := mustReceive[*frames.InputAudioRawFrame](t, c.got, "InputAudioRawFrame")
+	s0 := int16(binary.LittleEndian.Uint16(got.Audio[0:]))
+	s1 := int16(binary.LittleEndian.Uint16(got.Audio[2:]))
+	if s0 != -100 || s1 != 50 {
+		t.Fatalf("inverted samples = %d, %d, want -100, 50", s0, s1)
+	}
+
+	text := frames.NewTextFrame("leave me")
+	_ = p.QueueFrame(ctx, text, processor.Downstream)
+	out := mustReceive[*frames.TextFrame](t, c.got, "TextFrame")
+	if out.Text != "leave me" {
+		t.Fatalf("Text = %q", out.Text)
+	}
+}


### PR DESCRIPTION
## Summary
- `audio.DeinterleaveStereo` splits interleaved stereo back into left and right.
- `audio.Invert` and `processor.NewAudioInvert` flip PCM polarity, clipping the most negative sample.
- `frames.LLMContext.IsEmpty` reports whether any messages have been written.

Independent of the other open helper PRs: this branch is from current `main`.

## Test plan
- [ ] `go test ./audio ./frames ./processor`
- [ ] Confirm `DeinterleaveStereo` undoes `InterleaveStereo`
- [ ] Confirm a context with only a system prompt is empty
