### PR TITLE
feat: fade, silence padding, and user turn texts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- **Linear fades and silence padding.** `audio.Fade` ramps a buffer in and out.
+  `audio.PadSilence` and `processor.NewAudioPad` extend a chunk with zeros to a
+  minimum sample count, for a codec that wants a fixed leftover.
+
+- **Spoken user turns as text.** `frames.LLMContext.UserTexts` returns every
+  user message in order, skipping tool-result placeholders.
+
 - **A user turn processor.** `turns.NewUserTurnProcessor` decides the user's
   turn in a processor of its own, so the decision can be made once and shared
   by several aggregators, or placed at a particular point in the pipeline. The

--- a/audio/utils.go
+++ b/audio/utils.go
@@ -35,6 +35,61 @@ func IsSilence(pcm []byte) bool {
 	return true
 }
 
+// Fade applies a linear fade-in of inSamples and a linear fade-out of
+// outSamples to a chunk of 16-bit signed PCM. A fade that is longer than the
+// buffer covers the whole buffer. Where the two ramps overlap, the gains
+// multiply. Negative lengths are treated as zero. The result is a copy.
+func Fade(pcm []byte, inSamples, outSamples int) []byte {
+	n := len(pcm) - len(pcm)%2
+	out := make([]byte, n)
+	copy(out, pcm[:n])
+	if n == 0 {
+		return out
+	}
+	if inSamples < 0 {
+		inSamples = 0
+	}
+	if outSamples < 0 {
+		outSamples = 0
+	}
+	total := n / 2
+	for i := 0; i < total; i++ {
+		g := 1.0
+		if inSamples > 0 && i < inSamples {
+			g *= float64(i) / float64(inSamples)
+		}
+		if outSamples > 0 && i >= total-outSamples {
+			k := i - (total - outSamples)
+			g *= 1 - float64(k+1)/float64(outSamples)
+		}
+		if g == 1 {
+			continue
+		}
+		s := float64(int16(binary.LittleEndian.Uint16(out[i*2:]))) * g
+		binary.LittleEndian.PutUint16(out[i*2:], uint16(clampInt16(int32(s))))
+	}
+	return out
+}
+
+// PadSilence extends a chunk of 16-bit signed PCM with zeros until it holds at
+// least samples samples. A buffer that is already that long, or longer, is
+// copied as it stands. A trailing odd byte is dropped. The result is a copy.
+func PadSilence(pcm []byte, samples int) []byte {
+	if samples < 0 {
+		samples = 0
+	}
+	need := samples * 2
+	n := len(pcm) - len(pcm)%2
+	if n >= need {
+		out := make([]byte, n)
+		copy(out, pcm[:n])
+		return out
+	}
+	out := make([]byte, need)
+	copy(out, pcm[:n])
+	return out
+}
+
 // MixAudio sums two streams of 16-bit signed PCM sample by sample, clipping the
 // result to the 16-bit range. The streams need not be the same length: the
 // shorter one is treated as though it were padded with silence, so the result is

--- a/audio/utils_test.go
+++ b/audio/utils_test.go
@@ -64,6 +64,49 @@ func equal(got []int16, want ...int16) bool {
 	return true
 }
 
+func TestFade(t *testing.T) {
+	tests := []struct {
+		name       string
+		in         []byte
+		inS, outS  int
+		want       []int16
+	}{
+		{"empty", nil, 4, 4, nil},
+		{"no fade leaves the samples alone", pcm(100, -100), 0, 0, []int16{100, -100}},
+		{"fade in from silence", pcm(100, 100), 2, 0, []int16{0, 50}},
+		{"fade out to silence", pcm(100, 100), 0, 2, []int16{50, 0}},
+		{"negative lengths are zero", pcm(100, 100), -1, -1, []int16{100, 100}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := samples(audio.Fade(tt.in, tt.inS, tt.outS)); !equal(got, tt.want...) {
+				t.Errorf("Fade() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPadSilence(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      []byte
+		samples int
+		want    []int16
+	}{
+		{"empty stays empty when no pad is asked", nil, 0, nil},
+		{"pads with zeros", pcm(1, 2), 4, []int16{1, 2, 0, 0}},
+		{"already long enough is copied", pcm(1, 2, 3), 2, []int16{1, 2, 3}},
+		{"odd trailing byte is dropped", append(pcm(1), 0xFF), 2, []int16{1, 0}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := samples(audio.PadSilence(tt.in, tt.samples)); !equal(got, tt.want...) {
+				t.Errorf("PadSilence() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMixAudio(t *testing.T) {
 	tests := []struct {
 		name string

--- a/docs/concepts/llm-context.md
+++ b/docs/concepts/llm-context.md
@@ -24,7 +24,7 @@ long-lived aggregate shared between the aggregators and the LLM service, and it
 convo.AddUserMessage("What's the weather?")
 convo.AddAssistantMessage("Sunny and 22 degrees.")
 msgs := convo.Messages()          // a copy
-n := convo.EstimatedTokens()
+user := convo.UserTexts()         // spoken user turns, in order
 
 convo.SetSystem("You are terse.") // swap the prompt mid-conversation
 convo.SetTools(tools)             // change advertised tools

--- a/docs/guides/audio.md
+++ b/docs/guides/audio.md
@@ -150,6 +150,10 @@ buffer holds audio in memory.
 
 ## Other pieces
 
+- **`audio.Fade`**: a linear fade-in and fade-out on a complete PCM buffer
+  (a clip or a recorded utterance, not a 20 ms pipeline chunk).
+- **`audio.PadSilence`** / **`processor.NewAudioPad`**: extend a buffer or
+  every audio frame with zeros to a minimum sample count.
 - **`audio/onset`**: finds the first audible sample in a PCM stream, so
   time-to-first-audio metrics measure real speech rather than leading silence.
 - **`audio/chain.go`**: composes several `audio.Filter`s into one.

--- a/frames/llm_context.go
+++ b/frames/llm_context.go
@@ -465,6 +465,20 @@ func (c *LLMContext) Messages() []Message {
 	return cloneMessages(c.messages)
 }
 
+// UserTexts returns the text of every spoken user turn, in order, skipping
+// tool-result messages that share the user role. The slice is a copy.
+func (c *LLMContext) UserTexts() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, 0)
+	for _, m := range c.messages {
+		if m.Role == RoleUser && len(m.ToolResults) == 0 {
+			out = append(out, m.Text)
+		}
+	}
+	return out
+}
+
 // MessagesFor returns the messages to send to the named provider: every
 // universal one, plus the provider's own, and none written for a different
 // provider. It is what an adapter reads rather than Messages, so a conversation

--- a/frames/llm_context_test.go
+++ b/frames/llm_context_test.go
@@ -244,3 +244,22 @@ func TestSetMessagesDoesNotAliasTheCaller(t *testing.T) {
 		t.Errorf("context result = %q, want it untouched by the caller's slice", got)
 	}
 }
+
+// TestUserTexts collects spoken user turns and ignores tool-result placeholders.
+func TestUserTexts(t *testing.T) {
+	c := frames.NewLLMContext("system")
+	if got := c.UserTexts(); len(got) != 0 {
+		t.Errorf("UserTexts() = %v, want empty", got)
+	}
+
+	c.AddUserMessage("one")
+	c.AddAssistantMessage("reply")
+	c.AddUserMessage("two")
+	c.AddAssistantToolCall(frames.ToolCall{ID: "c1", Name: "get_weather"})
+	c.AddToolResult(frames.ToolResult{ID: "c1", Name: "get_weather", Content: "sunny"})
+
+	got := c.UserTexts()
+	if len(got) != 2 || got[0] != "one" || got[1] != "two" {
+		t.Errorf("UserTexts() = %v, want [one two]", got)
+	}
+}

--- a/processor/pad.go
+++ b/processor/pad.go
@@ -1,0 +1,37 @@
+package processor
+
+import (
+	"context"
+
+	"github.com/nuxflix/voxigo/audio"
+	"github.com/nuxflix/voxigo/frames"
+)
+
+// AudioPad extends every audio frame with silence until it holds at least
+// minSamples samples. A frame that is already that long is left alone. It is
+// for a codec or analyzer that wants a fixed minimum chunk and would rather
+// see trailing zeros than a short leftover.
+type AudioPad struct {
+	*Base
+	minSamples int
+}
+
+// NewAudioPad builds a processor that pads each audio frame to at least
+// minSamples samples.
+func NewAudioPad(minSamples int) *AudioPad {
+	p := &AudioPad{minSamples: minSamples}
+	p.Base = New("AudioPad", p)
+	return p
+}
+
+// ProcessFrame pads audio frames and forwards everything else.
+func (p *AudioPad) ProcessFrame(ctx context.Context, f frames.Frame, dir Direction) error {
+	if err := p.Base.ProcessFrame(ctx, f, dir); err != nil {
+		return err
+	}
+	if af, ok := f.(frames.AudioFrame); ok {
+		data := af.AudioData()
+		data.Audio = audio.PadSilence(data.Audio, p.minSamples)
+	}
+	return p.PushFrame(ctx, f, dir)
+}

--- a/processor/pad_test.go
+++ b/processor/pad_test.go
@@ -1,0 +1,60 @@
+package processor_test
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/nuxflix/voxigo/clock"
+	"github.com/nuxflix/voxigo/frames"
+	"github.com/nuxflix/voxigo/processor"
+)
+
+func pcm16pad(samples ...int16) []byte {
+	b := make([]byte, len(samples)*2)
+	for i, s := range samples {
+		binary.LittleEndian.PutUint16(b[i*2:], uint16(s))
+	}
+	return b
+}
+
+func TestAudioPadExtendsShortFramesAndPassesOtherFrames(t *testing.T) {
+	p := processor.NewAudioPad(4)
+	c := newCapture()
+	p.Link(c)
+
+	ctx := context.Background()
+	setup := processor.Setup{Clock: clock.NewSystem()}
+	if err := p.Setup(ctx, setup); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Setup(ctx, setup); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = p.Cleanup(ctx)
+		_ = c.Cleanup(ctx)
+	})
+
+	_ = p.QueueFrame(ctx, frames.NewStartFrame(), processor.Downstream)
+	mustReceive[*frames.StartFrame](t, c.got, "StartFrame")
+
+	in := frames.NewInputAudioRawFrame(pcm16pad(1, 2), 16000, 1)
+	_ = p.QueueFrame(ctx, in, processor.Downstream)
+	got := mustReceive[*frames.InputAudioRawFrame](t, c.got, "InputAudioRawFrame")
+	if len(got.Audio) != 8 {
+		t.Fatalf("padded length = %d, want 8", len(got.Audio))
+	}
+	s2 := int16(binary.LittleEndian.Uint16(got.Audio[4:]))
+	s3 := int16(binary.LittleEndian.Uint16(got.Audio[6:]))
+	if s2 != 0 || s3 != 0 {
+		t.Fatalf("pad samples = %d, %d, want 0, 0", s2, s3)
+	}
+
+	text := frames.NewTextFrame("leave me")
+	_ = p.QueueFrame(ctx, text, processor.Downstream)
+	out := mustReceive[*frames.TextFrame](t, c.got, "TextFrame")
+	if out.Text != "leave me" {
+		t.Fatalf("Text = %q", out.Text)
+	}
+}


### PR DESCRIPTION
## Summary
- `audio.Fade` applies a linear fade-in and fade-out on a complete PCM buffer.
- `audio.PadSilence` and `processor.NewAudioPad` extend a chunk with zeros to a minimum sample count.
- `frames.LLMContext.UserTexts` lists every spoken user turn, skipping tool-result placeholders.

Independent of the other open helper PRs: this branch is from current `main`.

## Test plan
- [ ] `go test ./audio ./frames ./processor`
- [ ] Confirm a 2-sample fade-in of `[100, 100]` becomes `[0, 50]`
- [ ] Confirm `UserTexts` ignores a tool-result message
