### PR TITLE
feat: hard limiter and assistant turn texts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- **A hard limiter.** `audio.Clamp` and `processor.NewAudioClamp` cap each
+  sample at ±maxAbs, so a loud burst is flattened rather than scaling the
+  whole utterance.
+
+- **Spoken assistant turns as text.** `frames.LLMContext.AssistantTexts`
+  returns every plain assistant reply in order, skipping tool-call turns.
+
 - **A user turn processor.** `turns.NewUserTurnProcessor` decides the user's
   turn in a processor of its own, so the decision can be made once and shared
   by several aggregators, or placed at a particular point in the pipeline. The

--- a/audio/utils.go
+++ b/audio/utils.go
@@ -35,6 +35,33 @@ func IsSilence(pcm []byte) bool {
 	return true
 }
 
+// Clamp limits each 16-bit signed sample to ±maxAbs. Values already inside the
+// range are left alone. A negative maxAbs is treated as zero. The result is a
+// copy. An empty buffer, or one that does not complete a sample, comes back
+// empty.
+func Clamp(pcm []byte, maxAbs int) []byte {
+	if maxAbs < 0 {
+		maxAbs = 0
+	}
+	if maxAbs > 32767 {
+		maxAbs = 32767
+	}
+	n := len(pcm) - len(pcm)%2
+	out := make([]byte, n)
+	limit := int32(maxAbs)
+	for i := 0; i+1 < n; i += 2 {
+		s := int32(int16(binary.LittleEndian.Uint16(pcm[i:])))
+		switch {
+		case s > limit:
+			s = limit
+		case s < -limit:
+			s = -limit
+		}
+		binary.LittleEndian.PutUint16(out[i:], uint16(int16(s)))
+	}
+	return out
+}
+
 // MixAudio sums two streams of 16-bit signed PCM sample by sample, clipping the
 // result to the 16-bit range. The streams need not be the same length: the
 // shorter one is treated as though it were padded with silence, so the result is

--- a/audio/utils_test.go
+++ b/audio/utils_test.go
@@ -64,6 +64,28 @@ func equal(got []int16, want ...int16) bool {
 	return true
 }
 
+func TestClamp(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     []byte
+		maxAbs int
+		want   []int16
+	}{
+		{"empty", nil, 100, nil},
+		{"inside the range is unchanged", pcm(50, -50), 100, []int16{50, -50}},
+		{"peaks are limited", pcm(200, -200, 10), 100, []int16{100, -100, 10}},
+		{"a negative limit is zero", pcm(50, -50), -1, []int16{0, 0}},
+		{"odd trailing byte is ignored", append(pcm(200), 0xFF), 100, []int16{100}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := samples(audio.Clamp(tt.in, tt.maxAbs)); !equal(got, tt.want...) {
+				t.Errorf("Clamp() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMixAudio(t *testing.T) {
 	tests := []struct {
 		name string

--- a/docs/concepts/llm-context.md
+++ b/docs/concepts/llm-context.md
@@ -24,7 +24,7 @@ long-lived aggregate shared between the aggregators and the LLM service, and it
 convo.AddUserMessage("What's the weather?")
 convo.AddAssistantMessage("Sunny and 22 degrees.")
 msgs := convo.Messages()          // a copy
-n := convo.EstimatedTokens()
+bot := convo.AssistantTexts()     // spoken assistant turns, in order
 
 convo.SetSystem("You are terse.") // swap the prompt mid-conversation
 convo.SetTools(tools)             // change advertised tools

--- a/docs/guides/audio.md
+++ b/docs/guides/audio.md
@@ -150,6 +150,8 @@ buffer holds audio in memory.
 
 ## Other pieces
 
+- **`audio.Clamp`** / **`processor.NewAudioClamp`**: a hard limiter that caps
+  each sample at ±maxAbs without scaling the rest of the buffer.
 - **`audio/onset`**: finds the first audible sample in a PCM stream, so
   time-to-first-audio metrics measure real speech rather than leading silence.
 - **`audio/chain.go`**: composes several `audio.Filter`s into one.

--- a/frames/llm_context.go
+++ b/frames/llm_context.go
@@ -465,6 +465,20 @@ func (c *LLMContext) Messages() []Message {
 	return cloneMessages(c.messages)
 }
 
+// AssistantTexts returns the text of every plain assistant turn, in order,
+// skipping tool-call messages. The slice is a copy.
+func (c *LLMContext) AssistantTexts() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, 0)
+	for _, m := range c.messages {
+		if m.Role == RoleAssistant && len(m.ToolCalls) == 0 && len(m.ToolResults) == 0 {
+			out = append(out, m.Text)
+		}
+	}
+	return out
+}
+
 // MessagesFor returns the messages to send to the named provider: every
 // universal one, plus the provider's own, and none written for a different
 // provider. It is what an adapter reads rather than Messages, so a conversation

--- a/frames/llm_context_test.go
+++ b/frames/llm_context_test.go
@@ -244,3 +244,22 @@ func TestSetMessagesDoesNotAliasTheCaller(t *testing.T) {
 		t.Errorf("context result = %q, want it untouched by the caller's slice", got)
 	}
 }
+
+// TestAssistantTexts collects spoken assistant turns and ignores tool calls.
+func TestAssistantTexts(t *testing.T) {
+	c := frames.NewLLMContext("system")
+	if got := c.AssistantTexts(); len(got) != 0 {
+		t.Errorf("AssistantTexts() = %v, want empty", got)
+	}
+
+	c.AddUserMessage("hello")
+	c.AddAssistantMessage("one")
+	c.AddUserMessage("again")
+	c.AddAssistantMessage("two")
+	c.AddAssistantToolCall(frames.ToolCall{ID: "c1", Name: "get_weather"})
+
+	got := c.AssistantTexts()
+	if len(got) != 2 || got[0] != "one" || got[1] != "two" {
+		t.Errorf("AssistantTexts() = %v, want [one two]", got)
+	}
+}

--- a/processor/clamp.go
+++ b/processor/clamp.go
@@ -1,0 +1,35 @@
+package processor
+
+import (
+	"context"
+
+	"github.com/nuxflix/voxigo/audio"
+	"github.com/nuxflix/voxigo/frames"
+)
+
+// AudioClamp limits every sample on every audio frame to ±maxAbs. It is a
+// hard limiter: peaks above the cap are flattened rather than scaled, so a
+// loud burst does not drag the rest of the utterance down with it.
+type AudioClamp struct {
+	*Base
+	maxAbs int
+}
+
+// NewAudioClamp builds a processor that limits each audio frame to ±maxAbs.
+func NewAudioClamp(maxAbs int) *AudioClamp {
+	p := &AudioClamp{maxAbs: maxAbs}
+	p.Base = New("AudioClamp", p)
+	return p
+}
+
+// ProcessFrame clamps audio frames and forwards everything else.
+func (p *AudioClamp) ProcessFrame(ctx context.Context, f frames.Frame, dir Direction) error {
+	if err := p.Base.ProcessFrame(ctx, f, dir); err != nil {
+		return err
+	}
+	if af, ok := f.(frames.AudioFrame); ok {
+		data := af.AudioData()
+		data.Audio = audio.Clamp(data.Audio, p.maxAbs)
+	}
+	return p.PushFrame(ctx, f, dir)
+}

--- a/processor/clamp_test.go
+++ b/processor/clamp_test.go
@@ -1,0 +1,58 @@
+package processor_test
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/nuxflix/voxigo/clock"
+	"github.com/nuxflix/voxigo/frames"
+	"github.com/nuxflix/voxigo/processor"
+)
+
+func pcm16clamp(samples ...int16) []byte {
+	b := make([]byte, len(samples)*2)
+	for i, s := range samples {
+		binary.LittleEndian.PutUint16(b[i*2:], uint16(s))
+	}
+	return b
+}
+
+func TestAudioClampLimitsPeaksAndPassesOtherFrames(t *testing.T) {
+	p := processor.NewAudioClamp(100)
+	c := newCapture()
+	p.Link(c)
+
+	ctx := context.Background()
+	setup := processor.Setup{Clock: clock.NewSystem()}
+	if err := p.Setup(ctx, setup); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Setup(ctx, setup); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = p.Cleanup(ctx)
+		_ = c.Cleanup(ctx)
+	})
+
+	_ = p.QueueFrame(ctx, frames.NewStartFrame(), processor.Downstream)
+	mustReceive[*frames.StartFrame](t, c.got, "StartFrame")
+
+	in := frames.NewInputAudioRawFrame(pcm16clamp(200, -200, 10), 16000, 1)
+	_ = p.QueueFrame(ctx, in, processor.Downstream)
+	got := mustReceive[*frames.InputAudioRawFrame](t, c.got, "InputAudioRawFrame")
+	s0 := int16(binary.LittleEndian.Uint16(got.Audio[0:]))
+	s1 := int16(binary.LittleEndian.Uint16(got.Audio[2:]))
+	s2 := int16(binary.LittleEndian.Uint16(got.Audio[4:]))
+	if s0 != 100 || s1 != -100 || s2 != 10 {
+		t.Fatalf("clamped samples = %d, %d, %d, want 100, -100, 10", s0, s1, s2)
+	}
+
+	text := frames.NewTextFrame("leave me")
+	_ = p.QueueFrame(ctx, text, processor.Downstream)
+	out := mustReceive[*frames.TextFrame](t, c.got, "TextFrame")
+	if out.Text != "leave me" {
+		t.Fatalf("Text = %q", out.Text)
+	}
+}


### PR DESCRIPTION
## Summary
- `audio.Clamp` and `processor.NewAudioClamp` cap each sample at a maximum absolute amplitude without scaling the rest of the utterance.
- `frames.LLMContext.AssistantTexts` lists every plain assistant reply, skipping tool-call turns.

Independent of the other open helper PRs: this branch is from current `main`.

## Test plan
- [ ] `go test ./audio ./frames ./processor`
- [ ] Confirm peaks at 200 and -200 clamp to 100 and -100 while a sample of 10 is unchanged
- [ ] Confirm `AssistantTexts` ignores an assistant tool-call message
